### PR TITLE
Fix testImplementation that failed to build enclave module

### DIFF
--- a/conclave-auction/enclave/build.gradle
+++ b/conclave-auction/enclave/build.gradle
@@ -5,7 +5,6 @@ plugins {
 dependencies {
     implementation project(":common")
     implementation "com.r3.conclave:conclave-enclave"
-    testImplementation "com.r3.conclave:conclave-host"
     testImplementation "org.junit.jupiter:junit-jupiter:5.6.0"
     compile group: 'com.esotericsoftware', name: 'kryo', version: '4.0.0'
 }

--- a/conclave-auction/enclave/build.gradle
+++ b/conclave-auction/enclave/build.gradle
@@ -5,7 +5,7 @@ plugins {
 dependencies {
     implementation project(":common")
     implementation "com.r3.conclave:conclave-enclave"
-    testImplementation "com.r3.conclave:conclave-testing"
+    testImplementation "com.r3.conclave:conclave-host"
     testImplementation "org.junit.jupiter:junit-jupiter:5.6.0"
     compile group: 'com.esotericsoftware', name: 'kryo', version: '4.0.0'
 }


### PR DESCRIPTION
The gradle build of `conclave-auction` wasfailing because `testImplementation "com.r3.conclave:conclave-testing"` is not present in `conclave-sdk-1.1/repo`.
After taking a look to the other samples, I saw that `/tribuo-classification/enclave/build.gradle` uses `"com.r3.conclave:conclave-host"` and so I thought it could be used in `conclave-auction` too.

Feel free to reject this PR if this modification is not correct.
