### PR TITLE
add mavenCentral repositories in EventManager/build.gradle

### DIFF
--- a/EventManager/build.gradle
+++ b/EventManager/build.gradle
@@ -3,6 +3,10 @@ plugins {
     id 'org.jetbrains.kotlin.jvm' version '1.4.21'
 }
 
+repositories {
+    mavenCentral()
+}
+
 group 'me.gendal.conclave.eventmanager'
 version '1.0-SNAPSHOT'
 


### PR DESCRIPTION
Without this in the root `build.gradle`, I get this error during the initial build:

```
Cannot resolve external dependency org.jetbrains.kotlin:kotlin-stdlib:1.4.21 because no repositories are defined.
Required by:
    project: 
```

