### PR TITLE
Fix constraint mention in the README and add note

### DIFF
--- a/conclave-auction/README.md
+++ b/conclave-auction/README.md
@@ -54,10 +54,14 @@ Run the client to sumbit a bid using the below command:
 
 `./gradlew runClient --args="BID <enclave_constraint>"`
 
-The enclave constraint can be found printed during the build process as below:
+The enclave constraint used in this sample is the `code signer`,  which can be found printed during the build process as in the example below:
 
-`Enclave code hash:   DB2AF8DD327D18965D50932E08BE4CB663436162CB7641269A4E611FC0956C5F`, In this 
-case the hash `DB2AF8DD327D18965D50932E08BE4CB663436162CB7641269A4E611FC0956C5F` is the enclave constraint.
+```
+Enclave code hash:   26037FC0370589FEA489110ED8124223650F5620B0732F94CDDEDDF207F07457
+Enclave code signer: 4502FEF2B5973A9DCF2F5C85358ED9F099C7738300364A7D7451371E43694A85
+```
+
+In this case the code signer `4502FEF2B5973A9DCF2F5C85358ED9F099C7738300364A7D7451371E43694A85` is the enclave constraint.
 
 You could run multiple clients to submit different bids.
 
@@ -96,3 +100,12 @@ To process the bid run the below command:
 The enclave should reply with a response message indicating 
 the auction winner to the admin client, and each individual bidders
 should get a response from the enclave regarding their bid status.
+
+#### More about enclave constraint
+In this sample the `code signer` is used as enclave constraint, but you can also use the `code hash`. If you want to use it, remember to change the code of the client to:
+
+`EnclaveConstraint.parse("C:"+ constraint +" SEC:INSECURE" ).check(attestation);`
+
+Read more in the https://docs.conclave.net/enclave-configuration.html#productid. 
+
+You can read more on the constraint here. https://docs.conclave.net/writing-hello-world.html#constraints.

--- a/psi-sample/README.md
+++ b/psi-sample/README.md
@@ -86,11 +86,19 @@ On your terminal, start Service Provider and pass in the credit card numbers of 
 Once both the clients pass in the credit card numbers, the host calculates the ad conversion rate within the enclave and sends it to both the clients.
 
 Please note:
-The enclave constraint to be passed to the client arguments can be found printed during the build process as below:
+The enclave constraint used in this sample is the `code signer`,  which can be found printed during the build process as in the example below:
 
-    Enclave code hash:   DB2AF8DD327D18965D50932E08BE4CB663436162CB7641269A4E611FC0956C5F`
-In this case the hash `DB2AF8DD327D18965D50932E08BE4CB663436162CB7641269A4E611FC0956C5F` is the enclave constraint.
+```
+Enclave code hash:   26037FC0370589FEA489110ED8124223650F5620B0732F94CDDEDDF207F07457
+Enclave code signer: 4502FEF2B5973A9DCF2F5C85358ED9F099C7738300364A7D7451371E43694A85
+```
 
+#### A note about enclave constraint
+In this sample the `code signer` is used as enclave constraint, but you can also use the `code hash`. If you want to use it, remember to change the code of the client to:
+
+`EnclaveConstraint.parse("C:"+ constraint +" SEC:INSECURE" ).check(attestation);`
+
+Read more in the [documentation](https://docs.conclave.net/enclave-configuration.html#productid).
 
 ## How to run in mock mode
 

--- a/tribuo-classification/README.md
+++ b/tribuo-classification/README.md
@@ -103,15 +103,19 @@ train the model inside the enclave and retrieve the evaluation result.
 
 To read more on Conclave go to the documentation site - https://docs.conclave.net
 
-Please note:
-The enclave constraint to be passed to the client arguments can be found printed during the build process as below:
 
-    Enclave code signer: AF89DF4211D742683C1CF940C78B7D5734CFAFA13EFAE65EC2A55643C0FE08CC
-In this case the code signer `AF89DF4211D742683C1CF940C78B7D5734CFAFA13EFAE65EC2A55643C0FE08CC` is the enclave constraint.
-For mock enclave, we will use S:0000000000000000000000000000000000000000000000000000000000000000 as the constraint.
+#### More about enclave constraint
+In this sample the `code signer` is used as enclave constraint, but you can also use the `code hash`. If you want to use it, remember to change the code of the client to:
+
+`EnclaveConstraint.parse("C:"+ constraint +" SEC:INSECURE" ).check(attestation);`
+
+Read more in the https://docs.conclave.net/enclave-configuration.html#productid.
+
+For mock enclave, we will use `S:0000000000000000000000000000000000000000000000000000000000000000` as the constraint.
 You can read more on the constraint here.
 https://docs.conclave.net/writing-hello-world.html#constraints
 
+---
 Please note:
 R3 code is licensed under Apache 2 but the training data set has its own terms and conditions, which you can read in the
 sample files.


### PR DESCRIPTION
Hi,

as discussed on [Slack](https://cordaledger.slack.com/archives/C012B3SST8R/p1629692912029500), the following samples
- conclave-auction
- psi-sample
- tribuo-classification

are using `S` (_code signer_) as enclave constraint, but in their README it was mentioned to use `C` (_code hash_). This PR fixes these mentions. 

I also took the liberty to add an additional note about enclave constraints to quickly show how to alternatively use the code hash. The reason is to have a README that is _self-contained_, so it explains - even if briefly - all the information that it mentions.