### PR TITLE
add conclaveRepo to global gradle.properties

### DIFF
--- a/EventManager/gradle.properties
+++ b/EventManager/gradle.properties
@@ -1,3 +1,2 @@
 kotlin.code.style=official
-conclaveRepo=<path_to_conclave_sdk>
 conclaveVersion=1.1

--- a/README.md
+++ b/README.md
@@ -44,11 +44,16 @@ This sample shows you how you can use the [Tribuo Java ML](https://tribuo.org/le
 ### Initial SetUp
 
 In order to compile and run all the samples successfully, kindly download the conclave SDK
-and update the conclaveRepo property in GRADLE_HOME/.gradle/gradle.properties as shown below
+and update the conclaveRepo property in GRADLE_USER_HOME/gradle.properties as shown below
             
-    conclaveRepo=<path-to-conclave-sdk>
+    conclaveRepo=<path-to-conclave-sdk-repo>
 
-Please note, if GRADLE_HOME is not set, it defaults to $USER_HOME/.gradle.
+Below is a sample gradle.properties file, which shows you how to set conclaveRepo to point to the repo folder inside conclave-sdk.
+
+    cat gradle.properties
+    conclaveRepo=/Users/sneha.damle/Documents/projects/conclave/conclave-sdk-1.1/repo
+
+Please note, if GRADLE_USER_HOME is not set, it defaults to $USER_HOME/.gradle.
 Once set, Conclave will always pick up the conclaveRepo from gradle.properties. To override this behaviour you can pass your own custom conclave sdk path via command line as show below.
 
     To override conclave sdk repo path and to load your enclave in mock mode

--- a/README.md
+++ b/README.md
@@ -7,9 +7,52 @@
 
 This repository contains multiple conclave sample applications which is intended to help
 developers to get started with the conclave platform and understand different features of
-the platform. To learn more about the Conclave platform please visit our official 
+the platform. To learn more about the Conclave platform please visit our official
 [documentation](https://docs.conclave.net/).
 
+### [EventManager](./EventManager):
+Event Manager implements the idea of an enclave that can simultaneously host a collection of 'Computations'. These computations are initiated by a Conclave client, have a name and a type, have a defined set of 'participants' and a 'quorum' that must be reached before a result (or results) can be obtained. Supported types are average (the average of the submissions is returned), maximum and minimum (the identity of the submitter of the highest or lowest value is returned) and "key matcher" (described below)
+
+The idea is that an enclave of this type could be used to host simple one-off multi-party computations (eg five employees wanting to know the average of their salaries, or ten firms wanting to know who had the lowest sales last month without revealing what that figure was).
+
+### [Column Profiling](./column-profiling):
+This sample does Column Profiling on the dataset and
+returns the frequency distribution as an output. Column profiling is one of the methods used in data profiling.
+This [link](https://www.alooma.com/blog/what-is-data-profiling) explains what data profiling and column profiling means
+and explains its uses and applications.
+
+### [Conclave Auction](./conclave-auction):
+This sample allows bidders to confidentially submit their bids to an enclave (A protected region of memory which cannot be accessed by the OS, Kernel or BIOS). The bids are processed confidentially in the enclave and the result is returned to concerned parties.
+
+### [Conclave Corda Trade](./conclave-corda-trade):
+This application serves as a demo for building a confidential trading system based on Corda and Conclave. An exchange Corda node would serve as a host which runs the enclave, while broker nodes servers as clients which send encryped order from their end-clients which are matched in the enclave and trades generated are recorded in all relevant participants ledgers.
+
+### [Psi](./psi-sample):
+PSI problem refers to the problem of determining the common elements from the intersection of two sets without leaking or disclosing any additional information of the remaining elements of the either sets.
+Using this sample will see how Conclave (based on Intel SGX) can be a new tool to solve the private set intersection (PSI) problem.
+
+### [Tribuo Classification](./tribuo-classification):
+Using this sample will see how Conclave (based on Intel SGX) can be used in training a ML model. We will use tribuo Java ML library to load the AI model.
+Most of the hospitals/doctors have lot of their patients' data, which can be used to determine whether a tumor is malignant or begnin.
+Such data can be used to train an AI model. Once a model is trained, this model can be used to predict if a given tumor is malignant
+or begnin given certain input attributes.
+
+### [Tribuo Tutorials](./tribuo-tutorials):
+Tribuo is a Java machine learning library, which makes it well suited to run with Conclave. This sample provides tools for classification, regression, clustering, model development, and more.
+This sample shows you how you can use the [Tribuo Java ML](https://tribuo.org/learn/4.0/tutorials/) library to load, train many models like classification models, regression models, clustering models etc.
+
+### Initial SetUp
+
+In order to compile and run all the samples successfully, kindly download the conclave SDK
+and update the conclaveRepo property in GRADLE_HOME/.gradle/gradle.properties as shown below
+            
+    conclaveRepo=<path-to-conclave-sdk>
+
+Please note, if GRADLE_HOME is not set, it defaults to $USER_HOME/.gradle.
+Once set, Conclave will always pick up the conclaveRepo from gradle.properties. To override this behaviour you can pass your own custom conclave sdk path via command line as show below.
+
+    To override conclave sdk repo path and to load your enclave in mock mode
+    ./gradlew host:run -PenclaveMode=mock -PconclaveRepo=<path-to-conclave-sdk>
 
 ## License
 The source code files are available under the Apache License, Version 2.0. 

--- a/column-profiling/gradle.properties
+++ b/column-profiling/gradle.properties
@@ -1,3 +1,2 @@
-
 conclaveVersion=1.1
-conclaveRepo=/path/to/conclave-sdk-1.1/repo
+

--- a/conclave-auction/gradle.properties
+++ b/conclave-auction/gradle.properties
@@ -1,4 +1,2 @@
-conclaveRepo=<path_to_conclave_sdk>
-#conclaveRepo=../conclave-sdk-1.1/repo
 conclaveVersion=1.1
 spring_boot_version=2.0.2.RELEASE

--- a/conclave-corda-trade/gradle.properties
+++ b/conclave-corda-trade/gradle.properties
@@ -1,8 +1,5 @@
 name=Trade CorDapp
 group=net.corda.samples.trade
 version=1.0
-
-#conclaveRepo=<path_to_conclave_sdk>
-conclaveRepo=../../conclave-sdk-1.1/repo
 conclaveVersion=1.1
 spring_boot_version=2.0.2.RELEASE

--- a/psi-sample/gradle.properties
+++ b/psi-sample/gradle.properties
@@ -1,4 +1,1 @@
-#
-#Tue Feb 09 22:52:29 GMT 2021
 conclaveVersion=1.1
-conclaveRepo=<path_to_conclave_sdk>

--- a/tribuo-classification/gradle.properties
+++ b/tribuo-classification/gradle.properties
@@ -1,5 +1,2 @@
-#
-#Tue Feb 09 22:52:29 GMT 2021
 conclaveVersion=1.1
-conclaveRepo=<path_to_conclave_sdk_repo>
 slf4j_version=1.7.30

--- a/tribuo-tutorials/gradle.properties
+++ b/tribuo-tutorials/gradle.properties
@@ -1,2 +1,1 @@
-conclaveRepo=<path/to/conclave/repo>
 conclaveVersion=1.1


### PR DESCRIPTION
This PR will be merged with 1.2 release.

For this PR we aim to remove the conclaveRepo property from all the individual gradle.properties files from all the projects.

We have described in the root README that now you can add a conclaveRepo property at GRADLE_HOME/.gradle/gradle.properties file. Doing so you dont have to maintain this property at individual project level.

To override this property you can pass in the new value via command line via the -P flag.
This helps the developer set the value only in one location.