### PR TITLE
CON-1063: Move CorDapp page from Conclave SDK docsite

### DIFF
--- a/cordapp/README.md
+++ b/cordapp/README.md
@@ -292,10 +292,10 @@ public class ReverseFlow extends FlowLogic<String> {
 }
 ```
 
-After establishing a session with the hosting node, the flow waits for an [`EnclaveInstanceInfo`](api/-conclave/com.r3.conclave.common/-enclave-instance-info/index.html) to verify it
+After establishing a session with the hosting node, the flow waits for an [`EnclaveInstanceInfo`](https://docs.conclave.net/api/-conclave/com.r3.conclave.common/-enclave-instance-info/index.html) to verify it
 against the constraint passed. If the enclave verifies successfully
 and doesn't throw an exception, the flow sends the initiator party identity to the enclave for
-[authentication](writing-cordapps.md#authenticating-senders-identity). The last step is applicable only if the party wishes to
+[authentication](#authenticating-senders-identity). The last step is applicable only if the party wishes to
 share its identity. The flow doesn't send any identity information if the `anonymous` parameter is set to `true`.
 
 
@@ -331,7 +331,7 @@ fun initiateFlow(flow: FlowLogic<*>, receiver: Party, constraint: String,
 After verifying the enclave and authenticating the identity (if the party shares its identity),
 the flow can securely exchange encrypted messages with the enclave through the `EnclaveFlowInitiator` instance.
 This instance implements a send/receive API that encrypts and decrypts the outgoing and incoming data in the form of byte arrays.
-The send and receive methods use the [`PostOffice`](api/-conclave/com.r3.conclave.mail/-post-office/index.html) API. The
+The send and receive methods use the [`PostOffice`](https://docs.conclave.net/api/-conclave/com.r3.conclave.mail/-post-office/index.html) API. The
 `EnclaveFlowInitiator` class holds one `PostOffice` instance which has the topic set to the session's flow id.
 
 ```kotlin
@@ -363,20 +363,20 @@ fun receiveFromEnclave(): ByteArray {
 }
 ```
 
-# Authenticating the sender's identity
+# Authenticating the sender's identity <a id="authenticating-senders-identity"></a>
 
 The enclave can authenticate a sender's identity that belongs to a network where nodes are identified by a X.509
 certificate, and the network is controlled by a certificate authority like in a Corda network.
 
 The network CA root certificate's public key must be stored in the enclave's resource folder (in this example the
-path is enclave/src/main/resources/) in a file named trustedroot.cer, so that the enclave can validate the sender
+path is enclave/src/main/resources/) in a file named trustedroot.cer, so that the enclave can validate the sender's
 identity.
 
 The identity is set up by the `EnclaveFlowInitiator` class during authentication and sent to the enclave which
 verifies it. Please be aware that the first byte of the identity message indicates whether a party wants to remain
 anonymous or not. If a party decides to remain anonymous, the identity message is padded with zeros to prevent
 anyone in the middle from using statistical analysis to guess whether a party is anonymous or not.
-The remaining bytes represent the party's identity If the party decides to authenticate
+The remaining bytes represent the party's identity if the party decides to authenticate
 itself.
 
 ```kotlin
@@ -433,7 +433,7 @@ protected void receiveMail(long id, EnclaveMail mail, String routingHint, Sender
 }
 ```
 
-The method `receiveMail` contains the enclave logic. You can code your business requirements in the `receiveMail method`.
+The method `receiveMail` contains the enclave logic. You can code your business requirements in this method.
 In the example above, the enclave reverses a string and returns the result back with the sender name if the party is not anonymous. The mail parameter contains some metadata, and the data which is going to be processed by the enclave.
 The call [`mail.getBodyAsBytes()`](https://docs.conclave.net/api/-conclave/com.r3.conclave.mail/-enclave-mail/index.html#-2025980493%2FFunctions%2F-654294413) returns
 the data to be processed by the enclave. As mentioned before, the `identity`

--- a/cordapp/README.md
+++ b/cordapp/README.md
@@ -74,7 +74,7 @@ For an explanation of the Docker command used above, see
 
 ## Corda Node Identity Validation
 The [certificates](certificates) folder contains the truststore.jks Java KeyStore that has the Corda Root
-Certificate Authority (CA) public key. This public key can be used for development or testing purposes. The public key also creates
+Certificate Authority (CA) public key. This public key can be used for development or testing purposes. The public key is also used to create
 the certificate *trustedroot.cer*, embedded as a resource in the enclave. This certificate is used to validate a Corda node's identity
 when the host relays a message to the enclave.
 

--- a/cordapp/README.md
+++ b/cordapp/README.md
@@ -1,6 +1,6 @@
 # CorDapp Sample
 
-This is a simple [CorDapp](https://docs.r3.com/en/platform/corda/4.8/open-source/cordapp-overview.html) written in Java using the Conclave API. It is licensed under the Apache 2 license. So, you 
+This is a simple [CorDapp](https://docs.r3.com/en/platform/corda/4.8/open-source/cordapp-overview.html) written in Java using the Conclave API. It is licensed under the Apache 2 license. So, you
 can copy/paste it to act as the basis of your commercial or open source apps.
 
 This CorDapp sample builds on the [hello-world](https://docs.conclave.net/writing-hello-world.html) sample. It reverses a string using two [nodes](https://docs.r3.com/en/platform/corda/4.8/enterprise/node/component-topology.html). One of these nodes is used to load the enclave.
@@ -10,13 +10,13 @@ This sample does not use smart contracts. It requires only flows.
 The sample divides the code into several parts. You can copy/paste the packages that _don't_ have `samples` in the name.
 The code expects a DCAP-capable host.
 
-!!! important
+*Note:
 To understand this tutorial, you should read both the [Conclave Hello World tutorial](https://docs.conclave.net/writing-hello-world.html)
-and [the Corda tutorials](https://docs.corda.net/docs/corda-os/4.7/hello-world-introduction.html).
+and [the Corda tutorials](https://docs.corda.net/docs/corda-os/4.7/hello-world-introduction.html).*
 
 ## How to run the sample CorDapp in different environments
 
-Unlike most CorDapps, this sample will *only run on Linux* due to the need for an enclave. However, you can use 
+Unlike most CorDapps, this sample will *only run on Linux* due to the need for an enclave. However, you can use
 virtualization to run it on Windows and macOS. For Windows and macOS, you need to set up a docker container.
 
 ### Linux
@@ -27,7 +27,7 @@ virtualization to run it on Windows and macOS. For Windows and macOS, you need t
 ### macOS
 
 1. Download and install Docker Desktop. Ensure that it is running.
-2. Download and unpack JDK 11 (LTS) and set `JAVA_HOME` environment variable to point to it. If you're already using 
+2. Download and unpack JDK 11 (LTS) and set `JAVA_HOME` environment variable to point to it. If you're already using
    versions 8 to 12, you can skip this step.
 3. Create and enter the Linux execution environment:
    ```
@@ -75,7 +75,7 @@ For an explanation of the Docker command used above, see
 ## Corda Node Identity Validation
 The [certificates](certificates) folder contains the truststore.jks Java KeyStore that has the Corda Root
 Certificate Authority (CA) public key. This public key can be used for development or testing purposes. The public key also creates
-the certificate *trustedroot.cer*, embedded as a resource in the enclave. This certificate is used to validate a Corda node's identity 
+the certificate *trustedroot.cer*, embedded as a resource in the enclave. This certificate is used to validate a Corda node's identity
 when the host relays a message to the enclave.
 
 To learn more about root certificates in the Corda network, please refer to
@@ -85,7 +85,7 @@ You can find the public Corda Network Root Certificate [here](https://trust.cord
 
 ### Usage
 Use the shell script `dmp-cordarootca.sh` to dump the Root CA certificate. Then, copy and paste the
-output to the cordapp/enclave/src/main/resources/trustedroot.cer. 
+output to the cordapp/enclave/src/main/resources/trustedroot.cer.
 
 *Note that this has been already
 done for you, and is reported here only for documentation purpose*.
@@ -133,9 +133,9 @@ dependencies {
 }
 ```
 
-!!! important
+*Note:
 You must use Gradle's `compile` configurations for the host dependencies. If you use `implementation`, you
-will get errors when the node starts up about missing classes due to issues with fat JARing. The host `dependencies` section should look like the above.
+will get errors when the node starts up about missing classes due to issues with fat JARing. The host `dependencies` section should look like the above snippet.*
 
 ## Write an enclave host service
 
@@ -155,7 +155,7 @@ public class ReverseEnclaveService extends EnclaveHostService {
 This will enable SGX support on the host. Then, it loads the sample `ReverseEnclave` class. The `EnclaveHostService` class exposes methods to
 send and receive mail with the enclave, and suspends flows waiting for the enclave to deliver mail.
 
-In the next section about relaying a mail from a flow to the enclave, Conclave uses 
+In the next section about relaying a mail from a flow to the enclave, Conclave uses
 the above class as a parameter to initiate the responder flow that ensures the host service is started.
 
 ## Relaying mail from a flow to the enclave
@@ -171,7 +171,7 @@ the other is the responder that reverses the string inside the enclave. To imple
 The responder flow to get the enclave host service up and running is as follows:
 
 1. Get the enclave attestation and send it to the other party for verification.
-2. Get, verify, and acknowledge the other party's encrypted identity. 
+2. Get, verify, and acknowledge the other party's encrypted identity.
 3. Get the other party's encrypted mail with the string to reverse.
 4. Send the string and the encrypted mail to the enclave.
 5. Retrieve the enclave-encrypted mail to send to the other party for decryption.
@@ -214,7 +214,7 @@ The flow responder expects to receive an identity during the initialization. You
 @Throws(FlowException::class)
 @JvmStatic
 @JvmOverloads
-fun <T : EnclaveHostService> initiateResponderFlow(flow: FlowLogic<*>, 
+fun <T : EnclaveHostService> initiateResponderFlow(flow: FlowLogic<*>,
                                                    counterPartySession: FlowSession,
                                                    serviceType: Class<T>): EnclaveFlowResponder {
     // Start an instance of the enclave hosting service
@@ -230,7 +230,7 @@ fun <T : EnclaveHostService> initiateResponderFlow(flow: FlowLogic<*>,
 
 The `EnclaveFlowResponder` implements a request/response protocol that receives an encrypted byte array
 and uses the `deliverAndPickUpMail` method of the `EnclaveHostService` class. This returns an operation that can be passed
-to `await`. The flow will suspend and free up its thread, potentially for an extended period. The enclave need not reply immediately. 
+to `await`. The flow will suspend and free up its thread, potentially for an extended period. The enclave need not reply immediately.
 It can return from processing the delivered mail without replying. When the enclave replies, the flow will be re-awakened, and the encrypted mail will be returned to the other side.
 
 ```kotlin
@@ -247,8 +247,8 @@ fun relayMessageToFromEnclave() {
 }
 ```
 
-!!! important
-This sample code does not handle node restarts, although the Corda flow framework has built-in support for it.
+*Note:
+This sample code does not handle node restarts, although the Corda flow framework has built-in support for it.*
 
 ### The Initiator Flow
 
@@ -257,7 +257,7 @@ The initiator flow that starts a session with the responder party is as follows:
 1. Get the enclave attestation and validate it.
 2. Build and send a verifiable identity for the enclave to validate.
 3. Send the encrypted mail with the string to reverse.
-4. Read and decrypt the enclave's response. Note that a verifiable identity is only sent to the enclave if the `anonymous`
+4. Read and decrypt the enclave's response. Remember that a verifiable identity is only sent to the enclave if the `anonymous`
 property is set to false.
 
 ```java
@@ -439,5 +439,5 @@ The call [`mail.getBodyAsBytes()`](https://docs.conclave.net/api/-conclave/com.r
 the data to be processed by the enclave. As mentioned before, the `identity`
 parameter object contains the identity of the sender if the sender is not anonymous. It is set to null if the sender is anonymous.
 
-!!! important
-The `receiveMail` method has an extra identity parameter in addition to the parameters in a regular enclave. You can check how this works in the [CordaEnclave class](https://github.com/R3Conclave/conclave-samples/blob/master/cordapp/enclave/src/main/kotlin/com/r3/conclave/cordapp/sample/enclave/CordaEnclave.kt).
+*Note:
+The `receiveMail` method has an extra identity parameter in addition to the parameters in a regular enclave. You can check how this works in the [CordaEnclave class](https://github.com/R3Conclave/conclave-samples/blob/master/cordapp/enclave/src/main/kotlin/com/r3/conclave/cordapp/sample/enclave/CordaEnclave.kt).*

--- a/cordapp/README.md
+++ b/cordapp/README.md
@@ -1,18 +1,17 @@
-# CorDapp Sample - Java
+# CorDapp Sample
 
-This is a simple [CorDapp](https://docs.r3.com/en/platform/corda/4.8/open-source/cordapp-overview.html) using the Conclave API. It is licensed under the Apache 2 license. So, you 
+This is a simple [CorDapp](https://docs.r3.com/en/platform/corda/4.8/open-source/cordapp-overview.html) written in Java using the Conclave API. It is licensed under the Apache 2 license. So, you 
 can copy/paste it to act as the basis of your commercial or open source apps.
 
-This CorDapp sample builds on the [hello-world](writing-hello-world.md) sample. It reverses a string using two [nodes](https://docs.r3.com/en/platform/corda/4.8/enterprise/node/component-topology.html). One of these nodes is used to load the enclave.
+This CorDapp sample builds on the [hello-world](https://docs.conclave.net/writing-hello-world.html) sample. It reverses a string using two [nodes](https://docs.r3.com/en/platform/corda/4.8/enterprise/node/component-topology.html). One of these nodes is used to load the enclave.
 
 This sample does not use smart contracts. It requires only flows.
 
 The sample divides the code into several parts. You can copy/paste the packages that _don't_ have `samples` in the name.
-The code expects a DCAP-capable host. If you want to use EPID, you can edit the enclave startup code to make it use your
-Intel API keys.
+The code expects a DCAP-capable host.
 
 !!! important
-To understand this tutorial, you should read both the [Conclave Hello World tutorial](writing-hello-world.md)
+To understand this tutorial, you should read both the [Conclave Hello World tutorial](https://docs.conclave.net/writing-hello-world.html)
 and [the Corda tutorials](https://docs.corda.net/docs/corda-os/4.7/hello-world-introduction.html).
 
 ## How to run the sample CorDapp in different environments
@@ -75,7 +74,7 @@ For an explanation of the Docker command used above, see
 
 ## Corda Node Identity Validation
 The [certificates](certificates) folder contains the truststore.jks Java KeyStore that has the Corda Root
-Certificate Authority (CA) public key. This public key can be used for development or testing purposes. It creates
+Certificate Authority (CA) public key. This public key can be used for development or testing purposes. The public key also creates
 the certificate *trustedroot.cer*, embedded as a resource in the enclave. This certificate is used to validate a Corda node's identity 
 when the host relays a message to the enclave.
 
@@ -86,7 +85,9 @@ You can find the public Corda Network Root Certificate [here](https://trust.cord
 
 ### Usage
 Use the shell script `dmp-cordarootca.sh` to dump the Root CA certificate. Then, copy and paste the
-output to the cordapp/enclave/src/main/resources/trustedroot.cer. *Note that this has been already
+output to the cordapp/enclave/src/main/resources/trustedroot.cer. 
+
+*Note that this has been already
 done for you, and is reported here only for documentation purpose*.
 
 ```shell
@@ -114,7 +115,7 @@ For instructions on how to set the mode at build time, see [here](https://docs.c
 ## Configure your workflow CorDapp module
 
 Both Conclave and Corda rely on Gradle build system plugins. Follow the instructions in the
-[hello world tutorial](writing-hello-world.md) to configure Gradle to include an enclave mode. Add the host libraries
+[hello world tutorial](https://docs.conclave.net/writing-hello-world.html) to configure Gradle to include an enclave mode. Add the host libraries
 to your Corda workflows module:
 
 ```
@@ -154,14 +155,14 @@ public class ReverseEnclaveService extends EnclaveHostService {
 This will enable SGX support on the host. Then, it loads the sample `ReverseEnclave` class. The `EnclaveHostService` class exposes methods to
 send and receive mail with the enclave, and suspends flows waiting for the enclave to deliver mail.
 
-In the next section about [relaying a mail from a flow to the enclave](writing-cordapps.md#relaying-mail-from-a-flow-to-the-enclave), Conclave uses 
+In the next section about relaying a mail from a flow to the enclave, Conclave uses 
 the above class as a parameter to initiate the responder flow that ensures the host service is started.
 
 ## Relaying mail from a flow to the enclave
 
-You have already seen how to [create a new subclass of enclave](writing-hello-world.md#create-a-new-subclass-of-enclave) and how to
-[receive and post mail in the enclave](writing-hello-world.md#receiving-and-post-mail-in-the-enclave) in the
-[hello-world](writing-hello-world.md) tutorial. Conclave has wrapped some of this boilerplate into an API to simplify setting up secure flows and exchanging secure messages between parties.
+You can see how to [create a new subclass of enclave](https://docs.conclave.net/writing-hello-world.html#create-a-new-subclass-of-enclave) and how to
+[receive and post mail in the enclave](https://docs.conclave.net/writing-hello-world.html#sending-and-receiving-mail) in the
+[hello-world](https://docs.conclave.net/writing-hello-world.html#sending-and-receiving-mail) tutorial. Conclave has wrapped some of this boilerplate into an API to simplify setting up secure flows and exchanging secure messages between parties.
 
 In this tutorial, reversing a string involves two parties: one is the initiator that sends the secret string to reverse, and
 the other is the responder that reverses the string inside the enclave. To implement this, you will need an *initiator* flow used by clients and a *responder* flow used by the host node.
@@ -434,7 +435,7 @@ protected void receiveMail(long id, EnclaveMail mail, String routingHint, Sender
 
 The method `receiveMail` contains the enclave logic. You can code your business requirements in the `receiveMail method`.
 In the example above, the enclave reverses a string and returns the result back with the sender name if the party is not anonymous. The mail parameter contains some metadata, and the data which is going to be processed by the enclave.
-The call [`mail.getBodyAsBytes()`](api/-conclave/com.r3.conclave.mail/-enclave-mail/get-body-as-bytes.html) returns
+The call [`mail.getBodyAsBytes()`](https://docs.conclave.net/api/-conclave/com.r3.conclave.mail/-enclave-mail/index.html#-2025980493%2FFunctions%2F-654294413) returns
 the data to be processed by the enclave. As mentioned before, the `identity`
 parameter object contains the identity of the sender if the sender is not anonymous. It is set to null if the sender is anonymous.
 

--- a/cordapp/README.md
+++ b/cordapp/README.md
@@ -152,7 +152,7 @@ public class ReverseEnclaveService extends EnclaveHostService {
 }
 ```
 
-This will enable SGX support on the host. Then, it loads the sample `ReverseEnclave` class. The `EnclaveHostService` class exposes methods to
+This loads the sample `ReverseEnclave` class. The `EnclaveHostService` class exposes methods to
 send and receive mail with the enclave, and suspends flows waiting for the enclave to deliver mail.
 
 In the next section about relaying a mail from a flow to the enclave, Conclave uses

--- a/cordapp/README.md
+++ b/cordapp/README.md
@@ -66,7 +66,7 @@ virtualization to run it on Windows and macOS. For Windows and macOS, you need t
     ./gradlew workflows:test
     ```
 
-Alternatively, Ubuntu 20.04 via WSL 2 ([Windows Subsystem for Linux 2](https://docs.microsoft.com/en-us/windows/wsl/install)
+Alternatively, Ubuntu 20.04 via WSL 2 ([Windows Subsystem for Linux 2](https://docs.microsoft.com/en-us/windows/wsl/install))
 may also prove to work for you, though this has not been extensively tested.
 
 For an explanation of the Docker command used above, see
@@ -141,7 +141,7 @@ will get errors when the node starts up about missing classes due to issues with
 
 Conclave loads the enclave into a service object. This singleton will be available to flows for later usage, and lets
 us integrate with the node's lifecycle. The sample project contains a helper class called `EnclaveHostService` that
-you can copy into your project and subclass. You need to edit this helper class to make it work for your use case.
+you can copy into your project and subclass. You can edit this helper class to make it work for your use case.
 
 ```java
 @CordaService

--- a/cordapp/README.md
+++ b/cordapp/README.md
@@ -1,13 +1,24 @@
 # CorDapp Sample - Java
 
-This is a simple CorDapp using the Conclave API. It is licensed under the Apache 2 license, and therefore you 
-may copy/paste it to act as the basis of your own commercial or open source apps.
+This is a simple [CorDapp](https://docs.r3.com/en/platform/corda/4.8/open-source/cordapp-overview.html) using the Conclave API. It is licensed under the Apache 2 license. So, you 
+can copy/paste it to act as the basis of your commercial or open source apps.
 
-## Usage
+This CorDapp sample builds on the [hello-world](writing-hello-world.md) sample. It reverses a string using two [nodes](https://docs.r3.com/en/platform/corda/4.8/enterprise/node/component-topology.html). One of these nodes is used to load the enclave.
 
-Unlike most CorDapps this one will *only run on Linux* due to the need for an enclave. But don't fear: you can use 
-virtualisation to run it on Windows and macOS as well. For Windows and macOS, this will unfortunately require you to
-do some manual work to set up a docker container (instructions below).
+This sample does not use smart contracts. It requires only flows.
+
+The sample divides the code into several parts. You can copy/paste the packages that _don't_ have `samples` in the name.
+The code expects a DCAP-capable host. If you want to use EPID, you can edit the enclave startup code to make it use your
+Intel API keys.
+
+!!! important
+To understand this tutorial, you should read both the [Conclave Hello World tutorial](writing-hello-world.md)
+and [the Corda tutorials](https://docs.corda.net/docs/corda-os/4.7/hello-world-introduction.html).
+
+## How to run the sample CorDapp in different environments
+
+Unlike most CorDapps, this sample will *only run on Linux* due to the need for an enclave. However, you can use 
+virtualization to run it on Windows and macOS. For Windows and macOS, you need to set up a docker container.
 
 ### Linux
 
@@ -16,9 +27,9 @@ do some manual work to set up a docker container (instructions below).
 
 ### macOS
 
-1. Download and install Docker Desktop if it isn't installed already. Ensure that it is running.
+1. Download and install Docker Desktop. Ensure that it is running.
 2. Download and unpack JDK 11 (LTS) and set `JAVA_HOME` environment variable to point to it. If you're already using 
-   versions 8 to 12 then you can skip this step.
+   versions 8 to 12, you can skip this step.
 3. Create and enter the Linux execution environment:
    ```
    ./gradlew enclave:setupLinuxExecEnvironment
@@ -29,7 +40,7 @@ do some manual work to set up a docker container (instructions below).
    ```
    apt-get -y update && apt-get install -y openjdk-8-jdk-headless && export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
    ```
-5. Change directory to your project and run the project as you would under Linux:
+5. Change directory to your project and run the project.
     ```
     cd <project-directory>
     ./gradlew workflows:test
@@ -37,9 +48,9 @@ do some manual work to set up a docker container (instructions below).
 
 ### Windows
 
-1. Download and install Docker Desktop if it isn't installed already. Ensure that it is running.
+1. Download and install Docker Desktop. Ensure that it is running.
 2. Download and unpack JDK 11 (LTS) and set `JAVA_HOME` environment variable to point to it. If you're already using
-   versions 8 to 12 then you can skip this step.
+   versions 8 to 12, you can skip this step.
 3. Create and enter the Linux execution environment:
     ```
     .\gradlew.bat enclave:setupLinuxExecEnvironment
@@ -50,31 +61,31 @@ do some manual work to set up a docker container (instructions below).
    ```
    apt-get -y update && apt-get install -y openjdk-8-jdk-headless && export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
    ```
-5. Change directory to your project and run the project as you would under Linux:
+5. Change directory to your project and run the project.
     ```
     cd <project-directory>
     ./gradlew workflows:test
     ```
 
-Alternatively, ubuntu 20.04 via WSL 2 ([Windows Subsystem for Linux 2](https://docs.microsoft.com/en-us/windows/wsl/install)
+Alternatively, Ubuntu 20.04 via WSL 2 ([Windows Subsystem for Linux 2](https://docs.microsoft.com/en-us/windows/wsl/install)
 may also prove to work for you, though this has not been extensively tested.
 
 For an explanation of the Docker command used above, see
 [the tutorials](https://docs.conclave.net/running-hello-world.html#appendix-summary-of-docker-command-options).
 
 ## Corda Node Identity Validation
-The [certificates](certificates) folder contains the truststore.jks Java KeyStore that contains the Corda Root
-certificate authority (CA) public key that can be used for development or testing purposes. It is used to generate 
-the trustedroot.cer that is then embedded as a resource in the enclave, and used to validate a Corda node's identity 
-when a message is relayed from the host to the enclave.
+The [certificates](certificates) folder contains the truststore.jks Java KeyStore that has the Corda Root
+Certificate Authority (CA) public key. This public key can be used for development or testing purposes. It creates
+the certificate *trustedroot.cer*, embedded as a resource in the enclave. This certificate is used to validate a Corda node's identity 
+when the host relays a message to the enclave.
 
 To learn more about root certificates in the Corda network, please refer to
 [the Corda documentation](https://docs.r3.com/en/platform/corda/4.8/open-source/permissioning.html).
 
-The public Corda Network Root Certificate can be found at https://trust.corda.network/.
+You can find the public Corda Network Root Certificate [here](https://trust.corda.network/).
 
 ### Usage
-Use the shell script `dmp-cordarootca.sh` to dump the Root CA cert, then copy and paste the
+Use the shell script `dmp-cordarootca.sh` to dump the Root CA certificate. Then, copy and paste the
 output to the cordapp/enclave/src/main/resources/trustedroot.cer. *Note that this has been already
 done for you, and is reported here only for documentation purpose*.
 
@@ -95,7 +106,337 @@ GqO4M1KlfimphQwCICiq00hDanT5W8bTLqE7GIGuplf/O8AABlpWrUg6uiUB
 -----END CERTIFICATE-----
 ```
 
-### Note on conclave modes
-By default, this sample will build and run in [mock mode](https://docs.conclave.net/mockmode.html), and so won't use a
-secure enclave. For a list of modes and their properties, see [here](https://docs.conclave.net/enclave-modes.html).
-For instructions on how to set the mode at build time, see [here](https://docs.conclave.net/running-hello-world.html#beyond-mock-mode)
+### Note on Conclave modes
+By default, this sample will build and run in [mock mode](https://docs.conclave.net/mockmode.html), so it won't use a
+secure enclave. For a list of Conclave modes and their properties, see [here](https://docs.conclave.net/enclave-modes.html).
+For instructions on how to set the mode at build time, see [here](https://docs.conclave.net/running-hello-world.html#beyond-mock-mode).
+
+## Configure your workflow CorDapp module
+
+Both Conclave and Corda rely on Gradle build system plugins. Follow the instructions in the
+[hello world tutorial](writing-hello-world.md) to configure Gradle to include an enclave mode. Add the host libraries
+to your Corda workflows module:
+
+```
+dependencies {
+    compile project(path: ":enclave", configuration: mode)
+    compile "com.r3.conclave:conclave-host:$conclaveVersion"
+    compile "com.r3.conclave:conclave-client:$conclaveVersion"
+    compile "com.r3.conclave:conclave-common:$conclaveVersion"
+    compile "com.r3.conclave:conclave-mail:$conclaveVersion"
+
+    // Corda dependencies.
+    cordaCompile "$corda_release_group:corda-core:$corda_release_version"
+    cordaRuntime "$corda_release_group:corda:$corda_release_version"
+    testCompile "$corda_release_group:corda-node-driver:$corda_release_version"
+}
+```
+
+!!! important
+You must use Gradle's `compile` configurations for the host dependencies. If you use `implementation`, you
+will get errors when the node starts up about missing classes due to issues with fat JARing. The host `dependencies` section should look like the above.
+
+## Write an enclave host service
+
+Conclave loads the enclave into a service object. This singleton will be available to flows for later usage, and lets
+us integrate with the node's lifecycle. The sample project contains a helper class called `EnclaveHostService` that
+you can copy into your project and subclass. You need to edit this helper class to make it work for your use case.
+
+```java
+@CordaService
+public class ReverseEnclaveService extends EnclaveHostService {
+    public ReverseEnclaveService(@NotNull AppServiceHub serviceHub) {
+        super("com.r3.conclave.cordapp.sample.enclave.ReverseEnclave");
+    }
+}
+```
+
+This will enable SGX support on the host. Then, it loads the sample `ReverseEnclave` class. The `EnclaveHostService` class exposes methods to
+send and receive mail with the enclave, and suspends flows waiting for the enclave to deliver mail.
+
+In the next section about [relaying a mail from a flow to the enclave](writing-cordapps.md#relaying-mail-from-a-flow-to-the-enclave), Conclave uses 
+the above class as a parameter to initiate the responder flow that ensures the host service is started.
+
+## Relaying mail from a flow to the enclave
+
+You have already seen how to [create a new subclass of enclave](writing-hello-world.md#create-a-new-subclass-of-enclave) and how to
+[receive and post mail in the enclave](writing-hello-world.md#receiving-and-post-mail-in-the-enclave) in the
+[hello-world](writing-hello-world.md) tutorial. Conclave has wrapped some of this boilerplate into an API to simplify setting up secure flows and exchanging secure messages between parties.
+
+In this tutorial, reversing a string involves two parties: one is the initiator that sends the secret string to reverse, and
+the other is the responder that reverses the string inside the enclave. To implement this, you will need an *initiator* flow used by clients and a *responder* flow used by the host node.
+
+### The Responder Flow
+The responder flow to get the enclave host service up and running is as follows:
+
+1. Get the enclave attestation and send it to the other party for verification.
+2. Get, verify, and acknowledge the other party's encrypted identity. 
+3. Get the other party's encrypted mail with the string to reverse.
+4. Send the string and the encrypted mail to the enclave.
+5. Retrieve the enclave-encrypted mail to send to the other party for decryption.
+
+```java
+// We start with a few lines of boilerplate: read the Corda tutorials to know more about it.
+@InitiatedBy(ReverseFlow.class)
+public class ReverseFlowResponder extends FlowLogic<Void> {
+
+    // private variable
+    private final FlowSession counterpartySession;
+
+    // Constructor
+    public ReverseFlowResponder(FlowSession counterpartySession) {
+        this.counterpartySession = counterpartySession;
+    }
+
+    @Suspendable
+    @Override
+    public Void call() throws FlowException {
+
+        EnclaveFlowResponder session =
+                EnclaveClientHelper.initiateResponderFlow(this, counterpartySession, ReverseEnclaveService.class);
+
+        session.relayMessageToFromEnclave();
+
+        return null;
+    }
+}
+```
+
+You can initiate the responder's flow by starting a specific instance of the
+`EnclaveHostService` and sending the remote attestation. All interactions with the enclave should start
+this way, although the attestation may be cached.
+
+The flow responder expects to receive an identity during the initialization. You can send an empty identity message if the party prefers to remain anonymous.
+
+```kotlin
+@Suspendable
+@Throws(FlowException::class)
+@JvmStatic
+@JvmOverloads
+fun <T : EnclaveHostService> initiateResponderFlow(flow: FlowLogic<*>, 
+                                                   counterPartySession: FlowSession,
+                                                   serviceType: Class<T>): EnclaveFlowResponder {
+    // Start an instance of the enclave hosting service
+    val host = flow.serviceHub.cordaService(serviceType)
+    // Send the other party the enclave identity (remote attestation) for verification.
+    counterPartySession.send(host.attestationBytes)
+    val instance = EnclaveFlowResponder(flow, counterPartySession, host)
+    // Relay the initial identity message to the enclave and relay the response back
+    instance.relayMessageToFromEnclave()
+    return instance
+}
+```
+
+The `EnclaveFlowResponder` implements a request/response protocol that receives an encrypted byte array
+and uses the `deliverAndPickUpMail` method of the `EnclaveHostService` class. This returns an operation that can be passed
+to `await`. The flow will suspend and free up its thread, potentially for an extended period. The enclave need not reply immediately. 
+It can return from processing the delivered mail without replying. When the enclave replies, the flow will be re-awakened, and the encrypted mail will be returned to the other side.
+
+```kotlin
+@Suspendable
+@Throws(FlowException::class)
+fun relayMessageToFromEnclave() {
+    // Other party sends us an encrypted mail.
+    val encryptedMail = session.receive(ByteArray::class.java).unwrap { it }
+    // Deliver and wait for the enclave to reply. The flow will suspend until the enclave chooses to deliver a mail
+    // to this flow, which might not be immediately.
+    val encryptedReply: ByteArray = flow.await(host.deliverAndPickUpMail(flow, encryptedMail))
+    // Send back to the other party the encrypted enclave's reply
+    session.send(encryptedReply)
+}
+```
+
+!!! important
+This sample code does not handle node restarts, although the Corda flow framework has built-in support for it.
+
+### The Initiator Flow
+
+The initiator flow that starts a session with the responder party is as follows:
+
+1. Get the enclave attestation and validate it.
+2. Build and send a verifiable identity for the enclave to validate.
+3. Send the encrypted mail with the string to reverse.
+4. Read and decrypt the enclave's response. Note that a verifiable identity is only sent to the enclave if the `anonymous`
+property is set to false.
+
+```java
+@InitiatingFlow
+@StartableByRPC
+public class ReverseFlow extends FlowLogic<String> {
+    private final Party receiver;
+    private final String message;
+    private final String constraint;
+    private final Boolean anonymous;
+
+    public ReverseFlow(Party receiver, String message, String constraint) {
+        this(receiver, message, constraint, false);
+    }
+
+    public ReverseFlow(Party receiver, String message, String constraint, Boolean anonymous) {
+        this.receiver = receiver;
+        this.message = message;
+        this.constraint = constraint;
+        this.anonymous = anonymous;
+    }
+
+    @Override
+    @Suspendable
+    public String call() throws FlowException {
+        EnclaveFlowInitiator session = EnclaveClientHelper.initiateFlow(this, receiver, constraint, anonymous);
+
+        byte[] response = session.sendAndReceive(message.getBytes(StandardCharsets.UTF_8));
+
+        return new String(response);
+    }
+}
+```
+
+After establishing a session with the hosting node, the flow waits for an [`EnclaveInstanceInfo`](api/-conclave/com.r3.conclave.common/-enclave-instance-info/index.html) to verify it
+against the constraint passed. If the enclave verifies successfully
+and doesn't throw an exception, the flow sends the initiator party identity to the enclave for
+[authentication](writing-cordapps.md#authenticating-senders-identity). The last step is applicable only if the party wishes to
+share its identity. The flow doesn't send any identity information if the `anonymous` parameter is set to `true`.
+
+
+
+```kotlin
+@Suspendable
+@Throws(FlowException::class)
+@JvmStatic
+@JvmOverloads
+fun initiateFlow(flow: FlowLogic<*>, receiver: Party, constraint: String,
+                 anonymous: Boolean = false): EnclaveFlowInitiator {
+    val session = flow.initiateFlow(receiver)
+
+    // Read the enclave attestation from the peer.
+    val attestation = session.receive(ByteArray::class.java).unwrap { from: ByteArray ->
+        EnclaveInstanceInfo.deserialize(from)
+    }
+
+    // The key hash below (the hex string after 'S') is the public key version of sample_private_key.pem
+    // In a real app you should remove the SEC:INSECURE part, of course.
+    try {
+        EnclaveConstraint.parse(constraint).check(attestation)
+    } catch (e: InvalidEnclaveException) {
+        throw FlowException(e)
+    }
+    val instance = EnclaveFlowInitiator(flow, session, attestation)
+    instance.sendIdentityToEnclave(anonymous)
+
+    return instance
+}
+```
+
+After verifying the enclave and authenticating the identity (if the party shares its identity),
+the flow can securely exchange encrypted messages with the enclave through the `EnclaveFlowInitiator` instance.
+This instance implements a send/receive API that encrypts and decrypts the outgoing and incoming data in the form of byte arrays.
+The send and receive methods use the [`PostOffice`](api/-conclave/com.r3.conclave.mail/-post-office/index.html) API. The
+`EnclaveFlowInitiator` class holds one `PostOffice` instance which has the topic set to the session's flow id.
+
+```kotlin
+@Suspendable
+@Throws(FlowException::class)
+fun sendAndReceive(messageBytes: ByteArray): ByteArray {
+    sendToEnclave(messageBytes)
+    return receiveFromEnclave()
+}
+
+@Suspendable
+@Throws(FlowException::class)
+private fun sendToEnclave(messageBytes: ByteArray) {
+    val encryptedMail = postOffice.encryptMail(messageBytes)
+    session.send(encryptedMail)
+}
+
+@Suspendable
+@Throws(FlowException::class)
+fun receiveFromEnclave(): ByteArray {
+    val reply: EnclaveMail = session.receive(ByteArray::class.java).unwrap { mail: ByteArray ->
+        try {
+            postOffice.decryptMail(mail)
+        } catch (e: IOException) {
+            throw FlowException("Unable to decrypt mail from Enclave", e)
+        }
+    }
+    return reply.bodyAsBytes
+}
+```
+
+# Authenticating the sender's identity
+
+The enclave can authenticate a sender's identity that belongs to a network where nodes are identified by a X.509
+certificate, and the network is controlled by a certificate authority like in a Corda network.
+
+The network CA root certificate's public key must be stored in the enclave's resource folder (in this example the
+path is enclave/src/main/resources/) in a file named trustedroot.cer, so that the enclave can validate the sender
+identity.
+
+The identity is set up by the `EnclaveFlowInitiator` class during authentication and sent to the enclave which
+verifies it. Please be aware that the first byte of the identity message indicates whether a party wants to remain
+anonymous or not. If a party decides to remain anonymous, the identity message is padded with zeros to prevent
+anyone in the middle from using statistical analysis to guess whether a party is anonymous or not.
+The remaining bytes represent the party's identity If the party decides to authenticate
+itself.
+
+```kotlin
+@Suspendable
+private fun buildMailerIdentity(): SenderIdentityImpl {
+    val sharedSecret = encryptionKey.publicKey.encoded
+    val signerPublicKey = flow.ourIdentity.owningKey
+    val signature = flow.serviceHub.keyManagementService.sign(sharedSecret, signerPublicKey).withoutKey()
+    val signerCertPath = flow.ourIdentityAndCert.certPath
+    return SenderIdentityImpl(signerCertPath, signature.bytes)
+}
+
+@Suspendable
+@Throws(FlowException::class)
+fun sendIdentityToEnclave(isAnonymous: Boolean) {
+
+    val serializedIdentity = getSerializedIdentity(isAnonymous)
+    sendToEnclave(serializedIdentity)
+
+    val mail: EnclaveMail = session.receive(ByteArray::class.java).unwrap { mail: ByteArray ->
+        try {
+            postOffice.decryptMail(mail)
+        } catch (e: IOException) {
+            throw FlowException("Unable to decrypt mail from Enclave", e)
+        }
+    }
+
+    if (!mail.topic.contentEquals("$flowTopic-ack"))
+        throw FlowException("The enclave could not validate the identity sent")
+}
+```
+
+When the enclave successfully validates the identity, it stores it in a key-based cache. Subsequent messages
+from the same sender in the same session are paired with the cached identity which is then available from
+within the `receiveMail` method through the extra parameter called `identity`. This identity can be used to uniquely identify a sender if the user is not anonymous.
+
+```java
+@Override
+protected void receiveMail(long id, EnclaveMail mail, String routingHint, SenderIdentity identity) {
+    String reversedString = reverse(new String(mail.getBodyAsBytes()));
+
+    String responseString;
+    if (identity == null) {
+        responseString = String.format("Reversed string: %s; Sender name: <Anonymous>", reversedString);
+    } else {
+        responseString = String.format("Reversed string: %s; Sender name: %s", reversedString, identity.getName());
+    }
+
+    // Get the PostOffice instance for responding back to this mail. Our response will use the same topic.
+    final EnclavePostOffice postOffice = postOffice(mail);
+    // Create the encrypted response and send it back to the sender.
+    final byte[] reply = postOffice.encryptMail(responseString.getBytes(StandardCharsets.UTF_8));
+    postMail(reply, routingHint);
+}
+```
+
+The method `receiveMail` contains the enclave logic. You can code your business requirements in the `receiveMail method`.
+In the example above, the enclave reverses a string and returns the result back with the sender name if the party is not anonymous. The mail parameter contains some metadata, and the data which is going to be processed by the enclave.
+The call [`mail.getBodyAsBytes()`](api/-conclave/com.r3.conclave.mail/-enclave-mail/get-body-as-bytes.html) returns
+the data to be processed by the enclave. As mentioned before, the `identity`
+parameter object contains the identity of the sender if the sender is not anonymous. It is set to null if the sender is anonymous.
+
+!!! important
+The `receiveMail` method has an extra identity parameter in addition to the parameters in a regular enclave. You can check how this works in the [CordaEnclave class](https://github.com/R3Conclave/conclave-samples/blob/master/cordapp/enclave/src/main/kotlin/com/r3/conclave/cordapp/sample/enclave/CordaEnclave.kt).


### PR DESCRIPTION
As part of the Jira ticket CON-1063-Move_CorDapp_page_from_the_docsite, I have integrated the info available on the doc - https://docs.conclave.net/writing-cordapps.html to the readme.md file on the conclave-samples repository. I have decided not to add too much information about Corda in this document. Instead, I have pointed to the Corda documentation wherever necessary.

I have also simplified the sentences and corrected a few spelling and grammar issues. I have raised [another PR](https://github.com/R3Conclave/conclave-sdk/pull/1157) for removing the CordApp document from the docs site.