### PR TITLE
CON-1217 - Updated Conclave's version

### DIFF
--- a/cordapp/build.gradle
+++ b/cordapp/build.gradle
@@ -77,19 +77,6 @@ allprojects {
     }
 
     repositories {
-        // Add the Conclave repository to every project.
-        maven {
-            def path = Paths.get(rootDir.absolutePath).resolve(conclaveRepo).toAbsolutePath().normalize()
-            if (!Files.isDirectory(path.resolve("com"))) {
-                if (Files.isDirectory(Paths.get("/repo/com"))) {
-                    path = Paths.get("/repo")
-                } else {
-                    throw new Exception("Neither $path nor /repo seem to exist, or they aren't Maven repositories; it should be the SDK 'repo' subdirectory.")
-                }
-            }
-            url = path.toFile()
-        }
-
         mavenCentral()
         maven { url 'https://ci-artifactory.corda.r3cev.com/artifactory/corda-releases' }
         maven { url 'https://software.r3.com/artifactory/corda' }

--- a/cordapp/gradle.properties
+++ b/cordapp/gradle.properties
@@ -1,8 +1,7 @@
 name=CorDappEnclave
 group=com.r3.conclave.samples.corda
 version=1.0
-# Note: if conclaveVersion and/or conclaveRepo are set in the user-wide gradle.properties file,
-# then these values will be ignored. See docs.conclave.net/gradle-properties.html for more information.
-conclaveVersion=1.2
-conclaveRepo=<path/to/conclave/repo>
+# Note: if conclaveVersion is set in the user-wide gradle.properties file,
+# then this value will be ignored. See docs.conclave.net/gradle-properties.html for more information.
+conclaveVersion=1.3
 

--- a/cordapp/settings.gradle
+++ b/cordapp/settings.gradle
@@ -3,18 +3,6 @@ import java.nio.file.Paths
 
 pluginManagement {
     repositories {
-        maven {
-            def path = Paths.get(rootDir.absolutePath).resolve(conclaveRepo).toAbsolutePath().normalize()
-            if (!Files.isDirectory(path.resolve("com"))) {
-                if (Files.isDirectory(Paths.get("/repo/com"))) {
-                    path = Paths.get("/repo")
-                } else {
-                    throw new Exception("Neither $path nor /repo seem to exist, or they aren't Maven repositories; it should be the SDK 'repo' subdirectory.")
-                }
-            }
-            url = path.toFile()
-        }
-        // Add standard repositories back.
         gradlePluginPortal()
         jcenter()
         mavenCentral()


### PR DESCRIPTION
Conclave 1.3 has been released. The CorDapp sample should now use Conclave 1.3 instead of 1.2. Conclave 1.3 is now open source so there is no need for the property `conclaveRepo` to exist. Conclave dependencies should be downloaded by Gradle from MavenCentral.