### PR TITLE
CON-1199 - workflows module should depend on the enclave module using the runtimeOnly keyword

### DIFF
--- a/cordapp/workflows/build.gradle
+++ b/cordapp/workflows/build.gradle
@@ -27,7 +27,7 @@ tasks.register("prepareForSigning") {
 
 dependencies {
     compile project(":common")
-    compile project(path: ":enclave", configuration: mode)
+    runtimeOnly project(path: ":enclave", configuration: mode)
 
     compile "com.r3.conclave:conclave-host:$conclaveVersion"
     compile "com.r3.conclave:conclave-client:$conclaveVersion"


### PR DESCRIPTION
Before this commit, the workflows module would depend on the enclave module as `compile` and would throw the exception:

java.lang.IllegalStateException: Multiple enclaves were found: [graalvm debug com.r3.conclave.cordapp.sample.enclave.ReverseEnclave, graalvm debug com.r3.conclave.cordapp.sample.enclave.ReverseEnclave]

The hello-world also uses runtimeOnly keyword instead of compile.