### PR TITLE
CON-1199: Revert runtimeOnly change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+build
+.gradle
+.idea
+.DS_Store

--- a/cordapp/gradle.properties
+++ b/cordapp/gradle.properties
@@ -1,7 +1,5 @@
 name=CorDappEnclave
 group=com.r3.conclave.samples.corda
 version=1.0
-# Note: if conclaveVersion is set in the user-wide gradle.properties file,
-# then this value will be ignored. See docs.conclave.net/gradle-properties.html for more information.
 conclaveVersion=1.3
 

--- a/cordapp/settings.gradle
+++ b/cordapp/settings.gradle
@@ -1,6 +1,3 @@
-import java.nio.file.Files
-import java.nio.file.Paths
-
 pluginManagement {
     repositories {
         gradlePluginPortal()
@@ -12,6 +9,8 @@ pluginManagement {
         id 'com.r3.conclave.enclave' version conclaveVersion apply false
     }
 }
+
+rootProject.name = "cordapp-sample"
 
 include 'common'
 include 'enclave'

--- a/cordapp/workflows/build.gradle
+++ b/cordapp/workflows/build.gradle
@@ -27,7 +27,7 @@ tasks.register("prepareForSigning") {
 
 dependencies {
     compile project(":common")
-    runtimeOnly project(path: ":enclave", configuration: mode)
+    compile project(path: ":enclave", configuration: mode)
 
     compile "com.r3.conclave:conclave-host:$conclaveVersion"
     compile "com.r3.conclave:conclave-client:$conclaveVersion"


### PR DESCRIPTION
`runtimeOnly` dependency on the enclave module does not work with CorDapps. The dependency needs to be declared as `compile` instead.

Unfortunately this is not picked up when running the tests, the Corda node has to be started manually for the issue to manifest. It seems the test classpath leaks in the enclave module which allows it to work. The QA tests would have picked this up, but we probably need to have some tests in the SDK repo as well.